### PR TITLE
Add HLS Playlist fetch service

### DIFF
--- a/.github/workflows/release-dev-prerelease.yml
+++ b/.github/workflows/release-dev-prerelease.yml
@@ -73,8 +73,14 @@ jobs:
             --dev-number "${{ steps.version.outputs.dev_number }}" \
             --target-url "https://tbsniller.github.io/SmartTwitchWebOSTV/dev/index.html"
 
+      - name: Prepare dev service variant
+        run: |
+          node tools/release/prepareDevServiceVariant.js \
+            --out-dir .tmp/dev-service \
+            --dev-appinfo .tmp/dev-app/appinfo.json
+
       - name: Build dev webOS package
-        run: npx ares-package .tmp/dev-app -o build/
+        run: npx ares-package .tmp/dev-app .tmp/dev-service -o build/
 
       - name: Generate prerelease manifest
         run: |

--- a/docs/WEBOS_LIMITATIONS.md
+++ b/docs/WEBOS_LIMITATIONS.md
@@ -99,6 +99,17 @@ Reason:
 Impact:
 - Removing or renaming hosted channels requires a dedicated migration refactor across wrapper defaults and CI workflows.
 
+## 10) Twitch `usher` Playlist Fetch and Quality Metadata on webOS
+
+Status: **Mitigated in fork bridge/service**
+
+Reason:
+- Some webOS TV browser engines block cross-origin XHR to `https://usher.ttvnw.net/...m3u8` (CORS), even when direct media playback still works.
+
+Impact:
+- Bridge routes `usher` HLS master playlist fetches through local webOS JS service (`com.tbsniller.smarttwitchwebostv.hls`) instead of a proxy fallback.
+- When playlist text is available, bridge parses variants and triggers quality refresh to keep UI options aligned with available tracks.
+
 ## Related Docs
 - Current implementation/parity snapshot: `docs/WEBOS_PORTING_STATUS.md`
 - Upstream sync procedure: `docs/UPSTREAM_SYNC_PLAYBOOK.md`

--- a/docs/WEBOS_PORTING_STATUS.md
+++ b/docs/WEBOS_PORTING_STATUS.md
@@ -14,6 +14,8 @@ This document is the canonical current-state snapshot for wrapper/bridge parity 
 - Core playback, preview playback, key handling, and platform-back flow are implemented.
 - Lifecycle handling (`visibilitychange`, `webkitvisibilitychange`, page show/hide) is implemented with guarded resume/stop behavior.
 - Relaunch/deeplink passthrough is implemented (`GetLastIntentObj`, `webOSRelaunch`).
+- Twitch `usher` HLS master playlist fetch is supported via local webOS JS service (`com.tbsniller.smarttwitchwebostv.hls`) to avoid browser CORS blocks on affected TVs.
+- Main-player quality list refresh mirrors Android timing by invoking `Play_getQualities(type, false)` from bridge after main playlist parse/start, keeping UI quality options in sync with parsed variants.
 
 ## Bridge/Parity Snapshot
 - Current bridge method totals in `initAndroid()`:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "sync:upstream:release": "node tools/upstream/syncUpstreamRelease.js",
     "sync:upstream:android-context": "node tools/upstream/syncUpstreamAndroidContext.js",
     "sync:upstream:all": "npm run sync:upstream:release && npm run sync:upstream:android-context",
-    "webos:package": "ares-package webos/app -o build/",
+    "webos:package": "ares-package webos/app webos/service -o build/",
     "webos:install": "node tools/webos/runAresCommand.js install",
     "webos:launch": "node tools/webos/runAresCommand.js launch",
     "webos:inspect": "node tools/webos/runAresCommand.js inspect",

--- a/tools/release/prepareDevServiceVariant.js
+++ b/tools/release/prepareDevServiceVariant.js
@@ -1,0 +1,160 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..', '..');
+const defaultStableServiceDir = path.join(root, 'webos', 'service');
+const defaultStableAppInfoPath = path.join(root, 'webos', 'app', 'appinfo.json');
+const defaultOutDir = path.join(root, '.tmp', 'dev-service');
+
+function parseArgs(argv) {
+    const args = {
+        outDir: defaultOutDir,
+        stableServiceDir: defaultStableServiceDir,
+        stableAppInfoPath: defaultStableAppInfoPath,
+        devAppInfoPath: ''
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        if (arg === '--help' || arg === '-h') {
+            console.log('Usage: node tools/release/prepareDevServiceVariant.js --dev-appinfo <path> [--out-dir <dir>] [--service-dir <dir>] [--stable-appinfo <path>]');
+            process.exit(0);
+        }
+
+        if (arg === '--out-dir') {
+            const next = argv[index + 1];
+            if (!next) throw new Error('Missing value for --out-dir');
+            args.outDir = resolvePath(next);
+            index += 1;
+            continue;
+        }
+        if (arg.indexOf('--out-dir=') === 0) {
+            args.outDir = resolvePath(arg.slice('--out-dir='.length));
+            continue;
+        }
+
+        if (arg === '--service-dir') {
+            const next = argv[index + 1];
+            if (!next) throw new Error('Missing value for --service-dir');
+            args.stableServiceDir = resolvePath(next);
+            index += 1;
+            continue;
+        }
+        if (arg.indexOf('--service-dir=') === 0) {
+            args.stableServiceDir = resolvePath(arg.slice('--service-dir='.length));
+            continue;
+        }
+
+        if (arg === '--stable-appinfo') {
+            const next = argv[index + 1];
+            if (!next) throw new Error('Missing value for --stable-appinfo');
+            args.stableAppInfoPath = resolvePath(next);
+            index += 1;
+            continue;
+        }
+        if (arg.indexOf('--stable-appinfo=') === 0) {
+            args.stableAppInfoPath = resolvePath(arg.slice('--stable-appinfo='.length));
+            continue;
+        }
+
+        if (arg === '--dev-appinfo') {
+            const next = argv[index + 1];
+            if (!next) throw new Error('Missing value for --dev-appinfo');
+            args.devAppInfoPath = resolvePath(next);
+            index += 1;
+            continue;
+        }
+        if (arg.indexOf('--dev-appinfo=') === 0) {
+            args.devAppInfoPath = resolvePath(arg.slice('--dev-appinfo='.length));
+            continue;
+        }
+
+        throw new Error('Unknown argument: ' + arg);
+    }
+
+    if (!args.devAppInfoPath) {
+        throw new Error('Missing --dev-appinfo');
+    }
+
+    return args;
+}
+
+function resolvePath(value) {
+    if (!value) throw new Error('Invalid path argument');
+    if (path.isAbsolute(value)) return value;
+    return path.resolve(root, value);
+}
+
+function readJson(filePath) {
+    if (!fs.existsSync(filePath)) {
+        throw new Error('Missing file: ' + filePath);
+    }
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+    fs.writeFileSync(filePath, JSON.stringify(value, null, 2) + '\n');
+}
+
+function ensureStartsWithPrefix(value, prefix, fieldName) {
+    if (typeof value !== 'string' || !value) {
+        throw new Error(fieldName + ' is missing');
+    }
+    if (value.indexOf(prefix) !== 0) {
+        throw new Error(fieldName + ' must start with app id prefix: ' + prefix + ', got: ' + value);
+    }
+}
+
+function rewritePrefixedId(value, stablePrefix, devPrefix) {
+    ensureStartsWithPrefix(value, stablePrefix, 'service id');
+    return devPrefix + value.slice(stablePrefix.length);
+}
+
+function main() {
+    const args = parseArgs(process.argv.slice(2));
+    const stableAppInfo = readJson(args.stableAppInfoPath);
+    const devAppInfo = readJson(args.devAppInfoPath);
+
+    const stableAppId = String(stableAppInfo.id || '').trim();
+    const devAppId = String(devAppInfo.id || '').trim();
+    if (!stableAppId) throw new Error('Stable app id missing in ' + args.stableAppInfoPath);
+    if (!devAppId) throw new Error('Dev app id missing in ' + args.devAppInfoPath);
+
+    if (!fs.existsSync(args.stableServiceDir)) {
+        throw new Error('Missing stable service directory: ' + args.stableServiceDir);
+    }
+
+    fs.rmSync(args.outDir, {recursive: true, force: true});
+    fs.cpSync(args.stableServiceDir, args.outDir, {recursive: true});
+
+    const servicesJsonPath = path.join(args.outDir, 'services.json');
+    const packageJsonPath = path.join(args.outDir, 'package.json');
+    const servicesJson = readJson(servicesJsonPath);
+    const packageJson = readJson(packageJsonPath);
+
+    const stableServiceId = String(servicesJson.id || packageJson.name || '').trim();
+    if (!stableServiceId) throw new Error('Stable service id missing in service metadata');
+
+    const devServiceId = rewritePrefixedId(stableServiceId, stableAppId, devAppId);
+
+    servicesJson.id = devServiceId;
+    if (Array.isArray(servicesJson.services)) {
+        for (let i = 0; i < servicesJson.services.length; i += 1) {
+            if (!servicesJson.services[i] || typeof servicesJson.services[i] !== 'object') continue;
+            const currentName = String(servicesJson.services[i].name || '').trim();
+            if (!currentName) continue;
+            servicesJson.services[i].name = rewritePrefixedId(currentName, stableAppId, devAppId);
+        }
+    }
+
+    packageJson.name = devServiceId;
+
+    writeJson(servicesJsonPath, servicesJson);
+    writeJson(packageJsonPath, packageJson);
+
+    console.log('Prepared dev service variant:');
+    console.log('- service dir: ' + args.outDir);
+    console.log('- service id: ' + devServiceId);
+}
+
+main();

--- a/webos/bridge/webosCompatBridge.js
+++ b/webos/bridge/webosCompatBridge.js
@@ -2608,6 +2608,26 @@
         var bridge = null;
         var timerId = 0;
         var settled = false;
+        var requestOrigin = '';
+        var requestReferer = '';
+        var requestUserAgent = '';
+        var requestAcceptLanguage = '';
+        try {
+            if (w.location && typeof w.location.origin === 'string' && /^https?:\/\//i.test(w.location.origin)) {
+                requestOrigin = w.location.origin;
+                requestReferer = requestOrigin + '/';
+            } else if (w.location && typeof w.location.href === 'string' && /^https?:\/\//i.test(w.location.href)) {
+                requestReferer = w.location.href;
+            }
+            if (w.navigator && typeof w.navigator.userAgent === 'string') requestUserAgent = w.navigator.userAgent;
+            if (w.navigator) {
+                if (Array.isArray(w.navigator.languages) && w.navigator.languages.length) {
+                    requestAcceptLanguage = w.navigator.languages.join(',');
+                } else if (typeof w.navigator.language === 'string' && w.navigator.language) {
+                    requestAcceptLanguage = w.navigator.language;
+                }
+            }
+        } catch (eLoc) {}
         var safeFinish = function (result, reason) {
             if (settled) return;
             settled = true;
@@ -2635,7 +2655,12 @@
                 safeFinish(normalized, 'service_ok');
                 return;
             }
-            safeFinish(null, 'service_bad_payload');
+            var reason = 'service_bad_payload';
+            if (parsed && typeof parsed === 'object') {
+                if (parsed.errorCode) reason = 'service_error_' + String(parsed.errorCode).toLowerCase();
+                else if (parsed.status) reason = 'service_status_' + String(parsed.status);
+            }
+            safeFinish(null, reason);
         };
         timerId = w.setTimeout(function () {
             safeFinish(null, 'service_timeout');
@@ -2643,7 +2668,11 @@
         try {
             bridge.call('luna://' + serviceName + '/fetchPlaylist', JSON.stringify({
                 url: requestUrl,
-                timeoutMs: getUsherPlaylistServiceTimeoutMs(timeoutMs)
+                timeoutMs: getUsherPlaylistServiceTimeoutMs(timeoutMs),
+                origin: requestOrigin || '',
+                referer: requestReferer || '',
+                userAgent: requestUserAgent || '',
+                acceptLanguage: requestAcceptLanguage || ''
             }));
         } catch (eCall) {
             safeFinish(null, 'service_call_exception');
@@ -2685,6 +2714,12 @@
             startedAt: Date.now()
         };
         callUsherPlaylistService(meta, timeoutMs, function (result, reason) {
+            bridgeDebugLog('usher_hls_service_result', {
+                reason: reason || '',
+                status: result && result.status ? result.status : 0,
+                hasPlaylist: !!(result && hasUsablePlaylistBody(result.responseText || '')),
+                url: meta && meta.url ? meta.url : ''
+            });
             if (result && result.status === 200 && hasUsablePlaylistBody(result.responseText)) {
                 cacheUsherPlaylistResult(meta.requestKey, result.responseText, result.url || meta.url || '');
                 cacheNetworkResponse(meta.requestKey, result.status, result.responseText);

--- a/webos/bridge/webosCompatBridge.js
+++ b/webos/bridge/webosCompatBridge.js
@@ -238,6 +238,13 @@
     var NETWORK_RTT_HOST_MAX = 64;                     // Max tracked RTT hosts.
     var NETWORK_PROBE_HOST_MAX = 32;                   // Max tracked probe hosts.
     var NETWORK_CIRCUIT_HOST_MAX = 48;                 // Max tracked circuit-breaker hosts.
+    var USHER_PLAYLIST_SERVICE_ID_SUFFIX = '.hls';     // Local JS service suffix appended to app id.
+    var USHER_PLAYLIST_SERVICE_TIMEOUT_MS = 4500;      // Timeout for local service playlist fetch.
+    var USHER_PLAYLIST_SERVICE_TIMEOUT_MIN_MS = 1200;  // Min allowed timeout sent to local service.
+    var USHER_PLAYLIST_SERVICE_TIMEOUT_MAX_MS = 7000;  // Max allowed timeout sent to local service.
+    var USHER_PLAYLIST_CACHE_TTL_MS = 45000;           // In-memory TTL for service-fetched playlists.
+    var USHER_PLAYLIST_CACHE_MAX = 24;                 // Max cached service playlist entries.
+    var USHER_PLAYLIST_INFLIGHT_MAX_AGE_MS = 20000;    // Safety prune age for stale in-flight entries.
     var PREVIEW_SET_COOLDOWN_MS = 450;                 // Dedup cooldown for repeated setPrev calls.
     var LIFECYCLE_STOP_MIN_HIDDEN_MS = 12000;          // Min hidden time before stopping playback.
     var STALL_PROGRESS_THRESHOLD_MS = 4000;            // No-progress window before stall is considered persistent.
@@ -256,6 +263,9 @@
     var networkResponseCacheByKey = {};       // Cached sync XHR responses by request key.
     var networkRttGlobalAvgMs = 0;            // Global average RTT across all hosts.
     var networkPruneLastAt = 0;               // Last network state prune timestamp.
+    var usherPlaylistCacheByKey = {};         // Short-TTL in-memory playlist cache (service path).
+    var usherPlaylistInFlightByKey = {};      // In-flight service fetch callbacks by request key.
+    var usherPlaylistCorsFailureSeen = false; // Session flag: if true, skip doomed browser XHR on usher playlist.
     // --- Loading indicator debounce ---
     // Loader show is delayed by DEBOUNCE_MS to prevent flicker on fast loads.
     // Loader hide is always immediate (canplay/playing/loadeddata events).
@@ -355,6 +365,19 @@
         } catch (e2) {
             return false;
         }
+    }
+    function isForceHlsServiceFetchEnabled() {
+        try {
+            if (w.location && typeof w.location.search === 'string' && /(?:\?|&)sttv_debug_force_hls_service_fetch=1(?:&|$)/i.test(w.location.search)) {
+                return true;
+            }
+        } catch (e0) {}
+        try {
+            if (!w.localStorage) return false;
+            var value = w.localStorage.getItem('STTV_DEBUG_FORCE_HLS_SERVICE_FETCH');
+            if (value === '1' || value === 'true' || value === 'TRUE') return true;
+        } catch (e1) {}
+        return false;
     }
     function bridgeDebugLog(event, extra) {
         if (!BRIDGE_DEBUG_ENABLED) return;
@@ -2482,19 +2505,22 @@
     function hasUsablePlaylistBody(text) {
         return typeof text === 'string' && text.indexOf('#EXTM3U') !== -1;
     }
-    function isUsherLiveHlsPath(pathLower) {
+    function isUsherPlaylistPath(pathLower) {
         if (!pathLower) return false;
         var normalizedPath = String(pathLower).toLowerCase().split('?')[0];
-        return /\/api\/channel\/hls\/[^\/\?]+\.m3u8$/.test(normalizedPath);
+        if (!/\.m3u8$/.test(normalizedPath)) return false;
+        if (normalizedPath.indexOf('/api/channel/hls/') === 0) return true;
+        if (normalizedPath.indexOf('/vod/') === 0) return true;
+        return false;
     }
-    function isUsherLivePlaylistRequest(meta) {
+    function isUsherPlaylistRequest(meta) {
         if (!meta) return false;
         if (meta.host !== 'usher.ttvnw.net') return false;
-        if (!isUsherLiveHlsPath(meta.pathLower || '')) return false;
+        if (!isUsherPlaylistPath(meta.pathLower || '')) return false;
         return String(meta.method || 'GET').toUpperCase() === 'GET';
     }
     function shouldUseUsherPlaylistCorsFallback(meta, status, text, reason) {
-        if (!isUsherLivePlaylistRequest(meta)) return false;
+        if (!isUsherPlaylistRequest(meta)) return false;
         var st = parseInt(status, 10) || 0;
         if (st > 0) return false;
         if (hasUsablePlaylistBody(text)) return false;
@@ -2515,6 +2541,156 @@
             url: fallbackUrl,
             synthetic: true
         };
+    }
+    function getWebOsAppId() {
+        try {
+            if (w.PalmSystem && w.PalmSystem.identifier) {
+                return String(w.PalmSystem.identifier).split(' ')[0] || '';
+            }
+        } catch (e) {}
+        return '';
+    }
+    function getUsherPlaylistServiceName() {
+        var appId = getWebOsAppId();
+        if (!appId) return '';
+        return appId + USHER_PLAYLIST_SERVICE_ID_SUFFIX;
+    }
+    function getUsherPlaylistServiceTimeoutMs(timeoutHint) {
+        var parsed = parseInt(timeoutHint, 10);
+        if (!isFinite(parsed) || parsed <= 0) parsed = USHER_PLAYLIST_SERVICE_TIMEOUT_MS;
+        return clamp(parsed, USHER_PLAYLIST_SERVICE_TIMEOUT_MIN_MS, USHER_PLAYLIST_SERVICE_TIMEOUT_MAX_MS);
+    }
+    function getUsherPlaylistCacheEntry(requestKey) {
+        if (!requestKey) return null;
+        var entry = usherPlaylistCacheByKey[requestKey];
+        if (!entry) return null;
+        var savedAt = parseInt(entry.savedAt, 10) || 0;
+        if (!savedAt || Date.now() - savedAt > USHER_PLAYLIST_CACHE_TTL_MS) {
+            delete usherPlaylistCacheByKey[requestKey];
+            return null;
+        }
+        return entry;
+    }
+    function cacheUsherPlaylistResult(requestKey, responseText, responseUrl) {
+        if (!requestKey || !hasUsablePlaylistBody(responseText)) return;
+        usherPlaylistCacheByKey[requestKey] = {
+            status: 200,
+            responseText: responseText,
+            responseUrl: responseUrl || '',
+            savedAt: Date.now()
+        };
+        pruneOldestMapEntries(usherPlaylistCacheByKey, USHER_PLAYLIST_CACHE_MAX);
+    }
+    function normalizeServicePlaylistResult(rawResult, meta) {
+        var payload = rawResult && typeof rawResult === 'object' ? rawResult : {};
+        var st = parseInt(payload.status, 10) || 0;
+        var text = typeof payload.responseText === 'string' ? payload.responseText : '';
+        if (st !== 200 || !hasUsablePlaylistBody(text)) return null;
+        var url = typeof payload.url === 'string' && payload.url ? payload.url : meta && meta.url ? meta.url : '';
+        return {
+            status: 200,
+            responseText: text,
+            url: url
+        };
+    }
+    function callUsherPlaylistService(meta, timeoutMs, done) {
+        var finish = typeof done === 'function' ? done : function () {};
+        var serviceName = getUsherPlaylistServiceName();
+        if (!serviceName || typeof w.PalmServiceBridge !== 'function') {
+            finish(null, 'service_unavailable');
+            return;
+        }
+        var requestUrl = meta && meta.url ? String(meta.url) : '';
+        if (!requestUrl) {
+            finish(null, 'missing_url');
+            return;
+        }
+        var bridge = null;
+        var timerId = 0;
+        var settled = false;
+        var safeFinish = function (result, reason) {
+            if (settled) return;
+            settled = true;
+            if (timerId) {
+                try { w.clearTimeout(timerId); } catch (eClear) {}
+                timerId = 0;
+            }
+            if (bridge) {
+                try { bridge.onservicecallback = null; } catch (eCb) {}
+                try { bridge.cancel(); } catch (eCancel) {}
+            }
+            bridge = null;
+            finish(result, reason || '');
+        };
+        try {
+            bridge = new w.PalmServiceBridge();
+        } catch (eBridge) {
+            safeFinish(null, 'service_bridge_create_fail');
+            return;
+        }
+        bridge.onservicecallback = function (msg) {
+            var parsed = safeParse(msg, null);
+            var normalized = normalizeServicePlaylistResult(parsed, meta);
+            if (normalized) {
+                safeFinish(normalized, 'service_ok');
+                return;
+            }
+            safeFinish(null, 'service_bad_payload');
+        };
+        timerId = w.setTimeout(function () {
+            safeFinish(null, 'service_timeout');
+        }, getUsherPlaylistServiceTimeoutMs(timeoutMs) + 150);
+        try {
+            bridge.call('luna://' + serviceName + '/fetchPlaylist', JSON.stringify({
+                url: requestUrl,
+                timeoutMs: getUsherPlaylistServiceTimeoutMs(timeoutMs)
+            }));
+        } catch (eCall) {
+            safeFinish(null, 'service_call_exception');
+        }
+    }
+    function flushUsherPlaylistInFlight(requestKey, result, reason) {
+        var inFlight = usherPlaylistInFlightByKey[requestKey];
+        if (!inFlight) return;
+        delete usherPlaylistInFlightByKey[requestKey];
+        var callbacks = inFlight.callbacks || [];
+        var i;
+        for (i = 0; i < callbacks.length; i++) {
+            try {
+                callbacks[i](result, reason || '');
+            } catch (eCb) {}
+        }
+    }
+    function requestUsherPlaylistViaService(meta, timeoutMs, done) {
+        var callback = typeof done === 'function' ? done : function () {};
+        if (!isUsherPlaylistRequest(meta) || !meta.requestKey) {
+            callback(null, 'not_usher_playlist');
+            return;
+        }
+        var cached = getUsherPlaylistCacheEntry(meta.requestKey);
+        if (cached) {
+            callback({
+                status: cached.status || 200,
+                responseText: cached.responseText || '',
+                url: cached.responseUrl || meta.url || ''
+            }, 'cache_hit');
+            return;
+        }
+        if (usherPlaylistInFlightByKey[meta.requestKey]) {
+            usherPlaylistInFlightByKey[meta.requestKey].callbacks.push(callback);
+            return;
+        }
+        usherPlaylistInFlightByKey[meta.requestKey] = {
+            callbacks: [callback],
+            startedAt: Date.now()
+        };
+        callUsherPlaylistService(meta, timeoutMs, function (result, reason) {
+            if (result && result.status === 200 && hasUsablePlaylistBody(result.responseText)) {
+                cacheUsherPlaylistResult(meta.requestKey, result.responseText, result.url || meta.url || '');
+                cacheNetworkResponse(meta.requestKey, result.status, result.responseText);
+            }
+            flushUsherPlaylistInFlight(meta.requestKey, result, reason);
+        });
     }
     function getEffectiveTimeoutMs(timeout, meta, sync) {
         var defaultCap = sync ? NETWORK_SYNC_MAX_TIMEOUT_MS : NETWORK_MAX_TIMEOUT_MS;
@@ -2565,7 +2741,22 @@
             var savedAt = entry && entry.savedAt ? parseInt(entry.savedAt, 10) || 0 : 0;
             if (!savedAt || now - savedAt > NETWORK_SYNC_CACHE_STALE_MAX_MS) delete networkResponseCacheByKey[key];
         }
+        for (key in usherPlaylistInFlightByKey) {
+            if (!Object.prototype.hasOwnProperty.call(usherPlaylistInFlightByKey, key)) continue;
+            var playlistInFlight = usherPlaylistInFlightByKey[key];
+            var playlistStartedAt = playlistInFlight && playlistInFlight.startedAt ? parseInt(playlistInFlight.startedAt, 10) || 0 : 0;
+            if (!playlistStartedAt || now - playlistStartedAt > USHER_PLAYLIST_INFLIGHT_MAX_AGE_MS) {
+                flushUsherPlaylistInFlight(key, null, 'pruned');
+            }
+        }
+        for (key in usherPlaylistCacheByKey) {
+            if (!Object.prototype.hasOwnProperty.call(usherPlaylistCacheByKey, key)) continue;
+            var playlistEntry = usherPlaylistCacheByKey[key];
+            var playlistSavedAt = playlistEntry && playlistEntry.savedAt ? parseInt(playlistEntry.savedAt, 10) || 0 : 0;
+            if (!playlistSavedAt || now - playlistSavedAt > USHER_PLAYLIST_CACHE_TTL_MS) delete usherPlaylistCacheByKey[key];
+        }
         pruneOldestMapEntries(networkResponseCacheByKey, NETWORK_RESPONSE_CACHE_MAX);
+        pruneOldestMapEntries(usherPlaylistCacheByKey, USHER_PLAYLIST_CACHE_MAX);
         pruneOldestMapEntries(networkRttByHost, NETWORK_RTT_HOST_MAX);
         pruneOldestMapEntries(networkMediaProbeByHost, NETWORK_PROBE_HOST_MAX);
         pruneOldestMapEntries(networkCircuitByHost, NETWORK_CIRCUIT_HOST_MAX);
@@ -2813,22 +3004,37 @@
         var body = req.body;
         var callback = typeof cb === 'function' ? cb : function () {};
         var meta = buildNetworkRequestMeta(u, method, body);
+        var forceServiceFetch = isForceHlsServiceFetchEnabled();
         maybePruneNetworkState();
         var effectiveTimeout = getEffectiveTimeoutMs(to, meta);
         var requestStartedAt = Date.now();
         var x;
         var done = false;
-        var finish = function (status, text, reason) {
+        var serviceAttempted = false;
+        var finish = function (status, text, reason, responseUrl, synthetic, skipServiceAttempt) {
             if (done) return;
+            if (!skipServiceAttempt && !serviceAttempted && shouldUseUsherPlaylistCorsFallback(meta, status, text, reason)) {
+                serviceAttempted = true;
+                usherPlaylistCorsFailureSeen = true;
+                bridgeDebugLog('usher_hls_cors_session_detected', {
+                    reason: reason || 'unknown',
+                    url: meta && meta.url ? meta.url : ''
+                });
+                requestUsherPlaylistViaService(meta, effectiveTimeout, function (serviceResult, serviceReason) {
+                    if (serviceResult && serviceResult.status === 200 && hasUsablePlaylistBody(serviceResult.responseText)) {
+                        finish(serviceResult.status, serviceResult.responseText, 'service_success', serviceResult.url || meta.url || '', true, true);
+                        return;
+                    }
+                    var fallback = buildUsherPlaylistCorsFallbackResult(meta, 0, serviceReason || reason || 'service_unavailable');
+                    finish(fallback.status, fallback.responseText, 'cors_fallback_synthetic', fallback.url, true, true);
+                });
+                return;
+            }
             done = true;
             if (meta.dedupeEnabled && meta.requestKey) clearInFlightRequestByKey(meta.requestKey, x);
-            var fallback = shouldUseUsherPlaylistCorsFallback(meta, status, text, reason)
-                ? buildUsherPlaylistCorsFallbackResult(meta, 0, reason)
-                : null;
-            var synthetic = !!(fallback && fallback.synthetic);
-            var finalStatus = fallback ? fallback.status : status || 0;
-            var finalText = fallback ? fallback.responseText : text || '';
-            var finalUrl = fallback && fallback.url ? fallback.url : '';
+            var finalStatus = status || 0;
+            var finalText = text || '';
+            var finalUrl = responseUrl || '';
             if (!synthetic) {
                 if (finalStatus > 0) {
                     cacheNetworkResponse(meta.requestKey, finalStatus, finalText);
@@ -2852,6 +3058,22 @@
             x = null;
             if (callbackRef) callbackRef(finalStatus, finalText, finalUrl);
         };
+        if (isUsherPlaylistRequest(meta) && (usherPlaylistCorsFailureSeen || forceServiceFetch)) {
+            if (forceServiceFetch) {
+                bridgeDebugLog('usher_hls_service_forced', {
+                    url: meta && meta.url ? meta.url : ''
+                });
+            }
+            requestUsherPlaylistViaService(meta, effectiveTimeout, function (serviceResult, serviceReason) {
+                if (serviceResult && serviceResult.status === 200 && hasUsablePlaylistBody(serviceResult.responseText)) {
+                    finish(serviceResult.status, serviceResult.responseText, 'service_success', serviceResult.url || meta.url || '', true, true);
+                    return;
+                }
+                var fallback = buildUsherPlaylistCorsFallbackResult(meta, 0, serviceReason || 'service_unavailable');
+                finish(fallback.status, fallback.responseText, 'service_fail_synthetic', fallback.url, true, true);
+            });
+            return;
+        }
         if (meta.circuitEnabled && isCircuitOpenForHost(meta.host)) {
             finish(0, '', 'circuit_open');
             return;
@@ -2883,6 +3105,7 @@
         var method = req.method;
         var body = req.body;
         var meta = buildNetworkRequestMeta(u, method, body);
+        var forceServiceFetch = isForceHlsServiceFetchEnabled();
         maybePruneNetworkState();
         var effectiveTimeout = getEffectiveTimeoutMs(to, meta, sync);
         // Stale-while-revalidate: for sync requests, serve cached data immediately
@@ -2894,6 +3117,24 @@
                 if (cached.isStale) sendAsyncRequest(u, to, pm, m, h, function () {});
                 return {status: cached.status, responseText: cached.responseText, checkResult: ck || 0};
             }
+        }
+        if (sync && isUsherPlaylistRequest(meta) && (usherPlaylistCorsFailureSeen || forceServiceFetch)) {
+            if (forceServiceFetch) {
+                bridgeDebugLog('usher_hls_service_forced_sync', {
+                    url: meta && meta.url ? meta.url : ''
+                });
+            }
+            var cachedUsherPlaylist = getUsherPlaylistCacheEntry(meta.requestKey);
+            if (cachedUsherPlaylist && hasUsablePlaylistBody(cachedUsherPlaylist.responseText || '')) {
+                return {
+                    status: 200,
+                    responseText: cachedUsherPlaylist.responseText,
+                    checkResult: ck || 0,
+                    url: cachedUsherPlaylist.responseUrl || meta.url || ''
+                };
+            }
+            requestUsherPlaylistViaService(meta, effectiveTimeout, function () {});
+            return buildUsherPlaylistCorsFallbackResult(meta, ck, 'service_deferred_sync');
         }
         if (meta.circuitEnabled && isCircuitOpenForHost(meta.host)) {
             if (sync) {
@@ -2932,6 +3173,8 @@
             } catch (e2) {
                 if (sync) {
                     if (shouldUseUsherPlaylistCorsFallback(meta, 0, '', 'request_exception')) {
+                        usherPlaylistCorsFailureSeen = true;
+                        requestUsherPlaylistViaService(meta, effectiveTimeout, function () {});
                         return buildUsherPlaylistCorsFallbackResult(meta, ck, 'request_exception');
                     }
                     if (meta.circuitEnabled) recordHostCircuitFailure(meta.host);
@@ -2944,6 +3187,8 @@
                 var syncStatus = x.status || 0;
                 var syncText = x.responseText || '';
                 if (shouldUseUsherPlaylistCorsFallback(meta, syncStatus, syncText, syncStatus > 0 ? 'success' : 'status0')) {
+                    usherPlaylistCorsFailureSeen = true;
+                    requestUsherPlaylistViaService(meta, effectiveTimeout, function () {});
                     return buildUsherPlaylistCorsFallbackResult(meta, ck, 'status0_sync');
                 }
                 if (syncStatus > 0) {

--- a/webos/bridge/webosCompatBridge.js
+++ b/webos/bridge/webosCompatBridge.js
@@ -2306,6 +2306,15 @@
             show(mv);
             try { mv.load(); } catch (e) {}
         }
+        // Align with Android PlayerActivity.onTracksChanged: refresh quality list
+        // for main player (live/vod) when not in PiP/multistream mode.
+        if (ms.type < 3 && !w.PlayExtra_PicturePicture && !w.Play_MultiEnable) {
+            call('Play_getQualities', [ms.type, false]);
+            bridgeDebugLog('main_quality_refresh_requested', {
+                type: ms.type,
+                parsedCount: ms.q.length
+            });
+        }
     }
     // Starts preview/feed playback. Deduplicates rapid repeated calls.
     // Rejects multi/extra/feed/side/screens modes when main is active (hardware limit).
@@ -4215,7 +4224,15 @@
             });
         };
         // IMPLEMENTED: Returns available quality options as JSON array.
-        A.getQualities = function () { var arr = [{id: 'Auto'}], i; for (i = 0; i < ms.q.length; i++) arr.push({id: ms.q[i].id}); return JSON.stringify(arr); };
+        A.getQualities = function () {
+            var arr = [{id: 'Auto'}], i;
+            for (i = 0; i < ms.q.length; i++) arr.push({id: ms.q[i].id});
+            bridgeDebugLog('get_qualities_called', {
+                count: arr.length,
+                ids: arr.map(function (item) { return item && item.id ? item.id : ''; }).slice(0, 8)
+            });
+            return JSON.stringify(arr);
+        };
         // IMPLEMENTED: Sets max resolution cap for main player.
         A.SetMainPlayerBitrate = function (bitrate, resolution) {
             void bitrate;

--- a/webos/bridge/webosCompatBridge.js
+++ b/webos/bridge/webosCompatBridge.js
@@ -1201,13 +1201,14 @@
         var seen = {};
         var i;
         for (i = 0; i < l.length; i++) {
-            if (l[i].indexOf('#EXT-X-STREAM-INF:') !== 0) continue;
-            var n = l[i + 1];
+            var streamLine = l[i] && typeof l[i] === 'string' ? l[i].trim() : '';
+            if (streamLine.toUpperCase().indexOf('#EXT-X-STREAM-INF:') !== 0) continue;
+            var n = l[i + 1] && typeof l[i + 1] === 'string' ? l[i + 1].trim() : '';
             if (!n || n.indexOf('#') === 0) continue;
-            var rm = l[i].match(/RESOLUTION=\d+x(\d+)/);
-            var fm = l[i].match(/FRAME-RATE=([0-9.]+)/);
-            var cm = l[i].match(/CODECS="([^"]+)"/i);
-            var bm = l[i].match(/(?:AVERAGE-)?BANDWIDTH=(\d+)/i);
+            var rm = streamLine.match(/RESOLUTION=\d+x(\d+)/i);
+            var fm = streamLine.match(/FRAME-RATE=([0-9.]+)/i);
+            var cm = streamLine.match(/CODECS="([^"]+)"/i);
+            var bm = streamLine.match(/(?:AVERAGE-)?BANDWIDTH=(\d+)/i);
             var r = rm && rm[1] ? parseInt(rm[1], 10) : 0;
             var f = fm && fm[1] ? Math.round(parseFloat(fm[1]) / 10) * 10 : 30;
             var bw = bm && bm[1] ? parseInt(bm[1], 10) : 0;
@@ -2276,6 +2277,12 @@
         ms.q = parseQ(ms.playlist, ms.rawUri);
         ms.qp = -1;
         ms.resume = rs > 0 ? rs : 0;
+        bridgeDebugLog('main_playlist_parsed', {
+            count: ms.q.length,
+            hasPlaylist: !!ms.playlist,
+            hasRawUri: !!ms.rawUri,
+            firstQuality: ms.q[0] && ms.q[0].id ? ms.q[0].id : ''
+        });
         ms.uri = sourceFromQuality(ms, mainMaxRes);
         if (mv) {
             mv.src = ms.uri;
@@ -4169,11 +4176,21 @@
             if (!mv || ms.type === 3) return;
             ms.qp = typeof pos === 'number' ? pos : -1;
             var tg = sourceFromQuality(ms, mainMaxRes);
+            bridgeDebugLog('set_quality_attempt', {
+                pos: ms.qp,
+                available: ms.q.length,
+                hasTarget: !!tg,
+                sameTarget: !!(tg && tg === mv.src)
+            });
             if (!tg || tg === mv.src) return;
             ms.resume = ms.type === 2 || ms.type === 3 ? mtime() : 0;
             ms.uri = tg;
             mv.src = tg;
             try { mv.load(); } catch (e) {}
+            bridgeDebugLog('set_quality_applied', {
+                pos: ms.qp,
+                available: ms.q.length
+            });
         };
         // IMPLEMENTED: Returns available quality options as JSON array.
         A.getQualities = function () { var arr = [{id: 'Auto'}], i; for (i = 0; i < ms.q.length; i++) arr.push({id: ms.q[i].id}); return JSON.stringify(arr); };

--- a/webos/bridge/webosCompatBridge.js
+++ b/webos/bridge/webosCompatBridge.js
@@ -725,8 +725,10 @@
         }
     }
     // Builds a JSON response string matching the Android sync XHR return format.
-    function res(st, tx, ck) {
-        return JSON.stringify({status: st || 0, responseText: tx || '', checkResult: ck || 0});
+    function res(st, tx, ck, u) {
+        var out = {status: st || 0, responseText: tx || '', checkResult: ck || 0};
+        if (typeof u === 'string' && u) out.url = u;
+        return JSON.stringify(out);
     }
     // =========================================================================
     // Key Dispatch
@@ -2448,6 +2450,7 @@
         var meta = safeParseRequestMeta(rawUrl);
         var host = meta.host;
         var pathLower = meta.pathLower;
+        var normalizedMethod = String(method || 'GET').toUpperCase();
         var key = '';
         var gqlHost = host.indexOf('gql.twitch.tv') !== -1 || pathLower === '/gql';
         var hlsId = extractHlsId(pathLower);
@@ -2467,10 +2470,50 @@
         }
         return {
             host: host,
+            url: meta.url || '',
+            pathLower: pathLower,
+            method: normalizedMethod,
             highRisk: isHighRiskHost(host),
             requestKey: key,
             circuitEnabled: !isCircuitExcludedHost(host, pathLower),
             dedupeEnabled: !isCoreTwitchHost(host)
+        };
+    }
+    function hasUsablePlaylistBody(text) {
+        return typeof text === 'string' && text.indexOf('#EXTM3U') !== -1;
+    }
+    function isUsherLiveHlsPath(pathLower) {
+        if (!pathLower) return false;
+        var normalizedPath = String(pathLower).toLowerCase().split('?')[0];
+        return /\/api\/channel\/hls\/[^\/\?]+\.m3u8$/.test(normalizedPath);
+    }
+    function isUsherLivePlaylistRequest(meta) {
+        if (!meta) return false;
+        if (meta.host !== 'usher.ttvnw.net') return false;
+        if (!isUsherLiveHlsPath(meta.pathLower || '')) return false;
+        return String(meta.method || 'GET').toUpperCase() === 'GET';
+    }
+    function shouldUseUsherPlaylistCorsFallback(meta, status, text, reason) {
+        if (!isUsherLivePlaylistRequest(meta)) return false;
+        var st = parseInt(status, 10) || 0;
+        if (st > 0) return false;
+        if (hasUsablePlaylistBody(text)) return false;
+        if (reason === 'timeout' || reason === 'abort' || reason === 'dedupe_abort' || reason === 'circuit_open') return false;
+        return true;
+    }
+    function buildUsherPlaylistCorsFallbackResult(meta, checkResult, reason) {
+        var fallbackUrl = meta && typeof meta.url === 'string' ? meta.url : '';
+        bridgeDebugLog('usher_hls_cors_fallback', {
+            reason: reason || 'unknown',
+            host: meta && meta.host ? meta.host : '',
+            url: fallbackUrl
+        });
+        return {
+            status: 200,
+            responseText: '',
+            checkResult: checkResult || 0,
+            url: fallbackUrl,
+            synthetic: true
         };
     }
     function getEffectiveTimeoutMs(timeout, meta, sync) {
@@ -2761,7 +2804,7 @@
         if (family && networkRttGlobalAvgMs > 0) return networkRttGlobalAvgMs;
         return 0;
     }
-    // Sends an async XHR request and invokes callback with (status, responseText, checkArgs...).
+    // Sends an async XHR request and invokes callback with (status, responseText, responseUrl).
     // Android: Android.XmlHttpGetFull() / Android.BasexmlHttpGet() via OkHttp.
     // webOS:   XHR with timeout, circuit-breaker, dedupe, and response caching.
     function sendAsyncRequest(u, to, pm, m, h, cb) {
@@ -2779,16 +2822,23 @@
             if (done) return;
             done = true;
             if (meta.dedupeEnabled && meta.requestKey) clearInFlightRequestByKey(meta.requestKey, x);
-            if (status > 0) {
-                cacheNetworkResponse(meta.requestKey, status, text);
-                recordNetworkRtt(meta.host, Date.now() - requestStartedAt);
-                if (meta.circuitEnabled) recordHostCircuitSuccess(meta.host);
-            } else if (meta.circuitEnabled && reason !== 'dedupe_abort' && reason !== 'circuit_open') {
-                recordHostCircuitFailure(meta.host);
+            var fallback = shouldUseUsherPlaylistCorsFallback(meta, status, text, reason)
+                ? buildUsherPlaylistCorsFallbackResult(meta, 0, reason)
+                : null;
+            var synthetic = !!(fallback && fallback.synthetic);
+            var finalStatus = fallback ? fallback.status : status || 0;
+            var finalText = fallback ? fallback.responseText : text || '';
+            var finalUrl = fallback && fallback.url ? fallback.url : '';
+            if (!synthetic) {
+                if (finalStatus > 0) {
+                    cacheNetworkResponse(meta.requestKey, finalStatus, finalText);
+                    recordNetworkRtt(meta.host, Date.now() - requestStartedAt);
+                    if (meta.circuitEnabled) recordHostCircuitSuccess(meta.host);
+                } else if (meta.circuitEnabled && reason !== 'dedupe_abort' && reason !== 'circuit_open') {
+                    recordHostCircuitFailure(meta.host);
+                }
             }
             var callbackRef = callback;
-            var finalStatus = status || 0;
-            var finalText = text || '';
             // Break XHR event handler retain cycles.
             if (x) {
                 try {
@@ -2800,7 +2850,7 @@
             }
             callback = null;
             x = null;
-            if (callbackRef) callbackRef(finalStatus, finalText);
+            if (callbackRef) callbackRef(finalStatus, finalText, finalUrl);
         };
         if (meta.circuitEnabled && isCircuitOpenForHost(meta.host)) {
             finish(0, '', 'circuit_open');
@@ -2881,6 +2931,9 @@
                 x.send(body ? body : null);
             } catch (e2) {
                 if (sync) {
+                    if (shouldUseUsherPlaylistCorsFallback(meta, 0, '', 'request_exception')) {
+                        return buildUsherPlaylistCorsFallbackResult(meta, ck, 'request_exception');
+                    }
                     if (meta.circuitEnabled) recordHostCircuitFailure(meta.host);
                     return {status: 0, responseText: '', checkResult: ck || 0};
                 } else if (meta.dedupeEnabled) {
@@ -2888,12 +2941,17 @@
                 }
             }
             if (sync) {
-                if ((x.status || 0) > 0) {
-                    cacheNetworkResponse(meta.requestKey, x.status || 0, x.responseText || '');
+                var syncStatus = x.status || 0;
+                var syncText = x.responseText || '';
+                if (shouldUseUsherPlaylistCorsFallback(meta, syncStatus, syncText, syncStatus > 0 ? 'success' : 'status0')) {
+                    return buildUsherPlaylistCorsFallbackResult(meta, ck, 'status0_sync');
+                }
+                if (syncStatus > 0) {
+                    cacheNetworkResponse(meta.requestKey, syncStatus, syncText);
                     recordNetworkRtt(meta.host, Date.now() - requestStartedAt);
                     if (meta.circuitEnabled) recordHostCircuitSuccess(meta.host);
                 } else if (meta.circuitEnabled) recordHostCircuitFailure(meta.host);
-                return {status: x.status || 0, responseText: x.responseText || '', checkResult: ck || 0};
+                return {status: syncStatus, responseText: syncText, checkResult: ck || 0};
             }
             return x;
         };
@@ -3748,11 +3806,11 @@
 
         // IMPLEMENTED: Synchronous HTTP request. Android: OkHttp sync call in WebView thread.
         // webOS: Sync XHR (blocks main thread). Required for upstream token fetch compatibility.
-        A.mMethodUrlHeaders = function (u, to, pm, m, ck, h) { var r = xhrReq(u, to, pm, m, ck, h, true); return res(r.status, r.responseText, r.checkResult); };
+        A.mMethodUrlHeaders = function (u, to, pm, m, ck, h) { var r = xhrReq(u, to, pm, m, ck, h, true); return res(r.status, r.responseText, r.checkResult, r.url); };
         // IMPLEMENTED: Async HTTP request (basic). Android: OkHttp async call.
         A.BasexmlHttpGet = function (u, to, pm, m, h, cb, ck, key, ok, err) { sendAsyncRequest(u, to, pm, m, h, function (status, text) { call(cb, [res(status, text, ck), key, ok, err, ck]); }); };
         // IMPLEMENTED: Async HTTP request (full, with extended check parameters). Android: OkHttp async.
-        A.XmlHttpGetFull = function (u, to, pm, m, h, cb, ck, c1, c2, c3, c4, c5, ok, err) { sendAsyncRequest(u, to, pm, m, h, function (status, text) { call(cb, [res(status, text, ck), ck, c1, c2, c3, c4, c5, ok, err]); }); };
+        A.XmlHttpGetFull = function (u, to, pm, m, h, cb, ck, c1, c2, c3, c4, c5, ok, err) { sendAsyncRequest(u, to, pm, m, h, function (status, text, responseUrl) { call(cb, [res(status, text, ck, responseUrl), ck, c1, c2, c3, c4, c5, ok, err]); }); };
 
         // --- Playback Start / Control ---
 

--- a/webos/bridge/webosCompatBridge.js
+++ b/webos/bridge/webosCompatBridge.js
@@ -1895,6 +1895,22 @@
         if (state.rawUri && (!maxRes || maxRes <= 0)) return state.rawUri;
         return pickFromMaster(state.rawUri, state.q, maxRes);
     }
+    function normalizeQualityPosition(pos, listLength) {
+        var parsed = -1;
+        if (typeof pos === 'number' && isFinite(pos)) {
+            parsed = Math.round(pos);
+        } else if (typeof pos === 'string') {
+            var trimmed = pos.trim();
+            if (trimmed) parsed = parseInt(trimmed, 10);
+        }
+        if (!isFinite(parsed)) parsed = -1;
+        if (parsed < -1) parsed = -1;
+        // Some runtimes may deliver 1-based indexes across bridge boundaries.
+        if (parsed >= 0 && listLength > 0 && parsed >= listLength && parsed - 1 >= 0 && parsed - 1 < listLength) {
+            parsed = parsed - 1;
+        }
+        return parsed;
+    }
     function clearMainStallTimer() {
         if (!mainStallTimerId) return;
         w.clearTimeout(mainStallTimerId);
@@ -4110,7 +4126,7 @@
         };
         // IMPLEMENTED: Prepare preview player for quality switch (pause + set quality position).
         A.ReuseFeedPlayerPrepare = function (trackSelectorPos) {
-            ps.qp = typeof trackSelectorPos === 'number' ? trackSelectorPos : -1;
+            ps.qp = normalizeQualityPosition(trackSelectorPos, ps.q.length);
             if (pv) try { pv.pause(); } catch (e) {}
         };
         // IMPLEMENTED: Switch from feed/preview to main player, or restart secondary.
@@ -4174,19 +4190,25 @@
         // Android: ExoPlayer TrackSelector. webOS: video.src swap from parsed playlist.
         A.SetQuality = function (pos) {
             if (!mv || ms.type === 3) return;
-            ms.qp = typeof pos === 'number' ? pos : -1;
+            var requestedPos = pos;
+            ms.qp = normalizeQualityPosition(pos, ms.q.length);
             var tg = sourceFromQuality(ms, mainMaxRes);
+            var currentSrc = (mv.currentSrc || mv.src || '');
+            var sameTarget = !!(tg && (tg === currentSrc || tg === mv.src));
             bridgeDebugLog('set_quality_attempt', {
+                rawPos: requestedPos,
+                rawType: typeof requestedPos,
                 pos: ms.qp,
                 available: ms.q.length,
                 hasTarget: !!tg,
-                sameTarget: !!(tg && tg === mv.src)
+                sameTarget: sameTarget
             });
-            if (!tg || tg === mv.src) return;
+            if (!tg || sameTarget) return;
             ms.resume = ms.type === 2 || ms.type === 3 ? mtime() : 0;
             ms.uri = tg;
             mv.src = tg;
             try { mv.load(); } catch (e) {}
+            tryPlay(mv);
             bridgeDebugLog('set_quality_applied', {
                 pos: ms.qp,
                 available: ms.q.length

--- a/webos/service/hls_service.js
+++ b/webos/service/hls_service.js
@@ -18,7 +18,6 @@ var MAX_RESPONSE_BYTES = 1024 * 1024;
 var DEFAULT_TIMEOUT_MS = 4500;
 var MIN_TIMEOUT_MS = 1200;
 var MAX_TIMEOUT_MS = 7000;
-var DEFAULT_BROWSER_UA = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36';
 var DEFAULT_ACCEPT_LANGUAGE = 'en-US,en;q=0.9';
 
 function clampTimeout(value) {
@@ -84,7 +83,7 @@ service.register('fetchPlaylist', function (message) {
     var timeoutMs = clampTimeout(payload.timeoutMs);
     var requestOrigin = normalizeHeaderValue(payload.origin, 256);
     var requestReferer = normalizeHeaderValue(payload.referer, 1024);
-    var requestUserAgent = normalizeHeaderValue(payload.userAgent, 512) || DEFAULT_BROWSER_UA;
+    var requestUserAgent = normalizeHeaderValue(payload.userAgent, 512);
     var requestAcceptLanguage = normalizeHeaderValue(payload.acceptLanguage, 256) || DEFAULT_ACCEPT_LANGUAGE;
     var finished = false;
 
@@ -96,11 +95,11 @@ service.register('fetchPlaylist', function (message) {
     var requestHeaders = {
         Accept: '*/*',
         'Accept-Encoding': 'identity',
-        'Accept-Language': requestAcceptLanguage,
-        'User-Agent': requestUserAgent
+        'Accept-Language': requestAcceptLanguage
     };
     if (requestOrigin) requestHeaders.Origin = requestOrigin;
     if (requestReferer) requestHeaders.Referer = requestReferer;
+    if (requestUserAgent) requestHeaders['User-Agent'] = requestUserAgent;
     requestHeaders['Sec-Fetch-Mode'] = 'cors';
     requestHeaders['Sec-Fetch-Site'] = 'cross-site';
 

--- a/webos/service/hls_service.js
+++ b/webos/service/hls_service.js
@@ -18,6 +18,8 @@ var MAX_RESPONSE_BYTES = 1024 * 1024;
 var DEFAULT_TIMEOUT_MS = 4500;
 var MIN_TIMEOUT_MS = 1200;
 var MAX_TIMEOUT_MS = 7000;
+var DEFAULT_BROWSER_UA = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36';
+var DEFAULT_ACCEPT_LANGUAGE = 'en-US,en;q=0.9';
 
 function clampTimeout(value) {
     var parsed = parseInt(value, 10);
@@ -46,6 +48,13 @@ function respondError(message, statusCode, errorCode, errorText) {
         errorText: errorText || 'Service error'
     });
 }
+function normalizeHeaderValue(value, maxLength) {
+    if (typeof value !== 'string') return '';
+    var cleaned = value.replace(/[\r\n]/g, ' ').trim();
+    if (!cleaned) return '';
+    if (maxLength > 0 && cleaned.length > maxLength) return cleaned.slice(0, maxLength);
+    return cleaned;
+}
 
 service.register('fetchPlaylist', function (message) {
     var payload = message && message.payload && typeof message.payload === 'object' ? message.payload : {};
@@ -73,6 +82,10 @@ service.register('fetchPlaylist', function (message) {
     }
 
     var timeoutMs = clampTimeout(payload.timeoutMs);
+    var requestOrigin = normalizeHeaderValue(payload.origin, 256);
+    var requestReferer = normalizeHeaderValue(payload.referer, 1024);
+    var requestUserAgent = normalizeHeaderValue(payload.userAgent, 512) || DEFAULT_BROWSER_UA;
+    var requestAcceptLanguage = normalizeHeaderValue(payload.acceptLanguage, 256) || DEFAULT_ACCEPT_LANGUAGE;
     var finished = false;
 
     var finalize = function (result) {
@@ -80,6 +93,16 @@ service.register('fetchPlaylist', function (message) {
         finished = true;
         message.respond(result);
     };
+    var requestHeaders = {
+        Accept: '*/*',
+        'Accept-Encoding': 'identity',
+        'Accept-Language': requestAcceptLanguage,
+        'User-Agent': requestUserAgent
+    };
+    if (requestOrigin) requestHeaders.Origin = requestOrigin;
+    if (requestReferer) requestHeaders.Referer = requestReferer;
+    requestHeaders['Sec-Fetch-Mode'] = 'cors';
+    requestHeaders['Sec-Fetch-Site'] = 'cross-site';
 
     var req = https.request(
         {
@@ -88,12 +111,7 @@ service.register('fetchPlaylist', function (message) {
             port: parsedUrl.port ? parsedUrl.port : 443,
             method: 'GET',
             path: parsedUrl.pathname + (parsedUrl.search || ''),
-            headers: {
-                Accept: 'application/vnd.apple.mpegurl,application/x-mpegURL,*/*;q=0.8',
-                'Accept-Encoding': 'identity',
-                Connection: 'keep-alive',
-                'User-Agent': 'SmartTwitchWebOSTV-HLSService/1.0'
-            }
+            headers: requestHeaders
         },
         function (res) {
             var status = parseInt(res.statusCode, 10) || 0;

--- a/webos/service/hls_service.js
+++ b/webos/service/hls_service.js
@@ -1,0 +1,180 @@
+/*
+ * SmartTwitchWebOSTV local webOS JS service for HLS playlist fetches.
+ * Keeps Twitch playlist fetches inside the app package service process so
+ * browser CORS restrictions do not block quality parsing in the hosted app.
+ */
+
+'use strict';
+
+var pkgInfo = require('./package.json');
+var Service = require('webos-service');
+var https = require('https');
+var urlLib = require('url');
+
+var service = new Service(pkgInfo.name);
+
+var ALLOWED_HOST = 'usher.ttvnw.net';
+var MAX_RESPONSE_BYTES = 1024 * 1024;
+var DEFAULT_TIMEOUT_MS = 4500;
+var MIN_TIMEOUT_MS = 1200;
+var MAX_TIMEOUT_MS = 7000;
+
+function clampTimeout(value) {
+    var parsed = parseInt(value, 10);
+    if (!isFinite(parsed) || parsed <= 0) parsed = DEFAULT_TIMEOUT_MS;
+    if (parsed < MIN_TIMEOUT_MS) parsed = MIN_TIMEOUT_MS;
+    if (parsed > MAX_TIMEOUT_MS) parsed = MAX_TIMEOUT_MS;
+    return parsed;
+}
+
+function isAllowedPlaylistUrl(parsedUrl) {
+    if (!parsedUrl) return false;
+    if (parsedUrl.protocol !== 'https:') return false;
+    if (String(parsedUrl.hostname || '').toLowerCase() !== ALLOWED_HOST) return false;
+    var path = String(parsedUrl.pathname || '').toLowerCase();
+    if (!/\.m3u8$/.test(path)) return false;
+    if (path.indexOf('/api/channel/hls/') === 0) return true;
+    if (path.indexOf('/vod/') === 0) return true;
+    return false;
+}
+
+function respondError(message, statusCode, errorCode, errorText) {
+    message.respond({
+        returnValue: false,
+        status: statusCode || 500,
+        errorCode: errorCode || 'UNKNOWN',
+        errorText: errorText || 'Service error'
+    });
+}
+
+service.register('fetchPlaylist', function (message) {
+    var payload = message && message.payload && typeof message.payload === 'object' ? message.payload : {};
+    var targetUrl = typeof payload.url === 'string' ? payload.url : '';
+    if (!targetUrl) {
+        respondError(message, 400, 'INVALID_URL', 'payload.url is required');
+        return;
+    }
+
+    var parsedUrl = null;
+    try {
+        parsedUrl = urlLib.parse(targetUrl);
+    } catch (eUrl) {
+        respondError(message, 400, 'INVALID_URL', 'payload.url is not a valid URL');
+        return;
+    }
+    if (!parsedUrl || !parsedUrl.hostname) {
+        respondError(message, 400, 'INVALID_URL', 'payload.url is not a valid URL');
+        return;
+    }
+
+    if (!isAllowedPlaylistUrl(parsedUrl)) {
+        respondError(message, 403, 'URL_NOT_ALLOWED', 'Only usher Twitch playlist URLs are allowed');
+        return;
+    }
+
+    var timeoutMs = clampTimeout(payload.timeoutMs);
+    var finished = false;
+
+    var finalize = function (result) {
+        if (finished) return;
+        finished = true;
+        message.respond(result);
+    };
+
+    var req = https.request(
+        {
+            protocol: 'https:',
+            hostname: parsedUrl.hostname,
+            port: parsedUrl.port ? parsedUrl.port : 443,
+            method: 'GET',
+            path: parsedUrl.pathname + (parsedUrl.search || ''),
+            headers: {
+                Accept: 'application/vnd.apple.mpegurl,application/x-mpegURL,*/*;q=0.8',
+                'Accept-Encoding': 'identity',
+                Connection: 'keep-alive',
+                'User-Agent': 'SmartTwitchWebOSTV-HLSService/1.0'
+            }
+        },
+        function (res) {
+            var status = parseInt(res.statusCode, 10) || 0;
+            if (status !== 200) {
+                try { res.resume(); } catch (eResume) {}
+                finalize({
+                    returnValue: false,
+                    status: status > 0 ? status : 502,
+                    errorCode: 'UPSTREAM_STATUS',
+                    errorText: 'Upstream returned status ' + status
+                });
+                return;
+            }
+
+            var chunks = [];
+            var totalBytes = 0;
+
+            res.on('data', function (chunk) {
+                if (finished) return;
+                totalBytes += chunk.length;
+                if (totalBytes > MAX_RESPONSE_BYTES) {
+                    req.destroy(new Error('RESPONSE_TOO_LARGE'));
+                    return;
+                }
+                chunks.push(chunk);
+            });
+
+            res.on('end', function () {
+                if (finished) return;
+                var body = '';
+                try {
+                    body = Buffer.concat(chunks).toString('utf8');
+                } catch (eConcat) {
+                    finalize({
+                        returnValue: false,
+                        status: 500,
+                        errorCode: 'DECODE_ERROR',
+                        errorText: 'Failed to decode playlist body'
+                    });
+                    return;
+                }
+
+                if (body.indexOf('#EXTM3U') === -1) {
+                    finalize({
+                        returnValue: false,
+                        status: 502,
+                        errorCode: 'INVALID_PLAYLIST',
+                        errorText: 'Playlist body does not contain EXTM3U header'
+                    });
+                    return;
+                }
+
+                finalize({
+                    returnValue: true,
+                    status: 200,
+                    responseText: body,
+                    url: targetUrl
+                });
+            });
+        }
+    );
+
+    req.setTimeout(timeoutMs, function () {
+        req.destroy(new Error('TIMEOUT'));
+    });
+
+    req.on('error', function (err) {
+        if (finished) return;
+        var messageText = err && err.message ? String(err.message) : 'Network request failed';
+        var errorCode = messageText === 'RESPONSE_TOO_LARGE' ? 'RESPONSE_TOO_LARGE' : messageText === 'TIMEOUT' ? 'TIMEOUT' : 'NETWORK_ERROR';
+        var statusCode = messageText === 'RESPONSE_TOO_LARGE' ? 413 : messageText === 'TIMEOUT' ? 504 : 502;
+        finalize({
+            returnValue: false,
+            status: statusCode,
+            errorCode: errorCode,
+            errorText: messageText
+        });
+    });
+
+    req.end();
+});
+
+
+

--- a/webos/service/package.json
+++ b/webos/service/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "com.tbsniller.smarttwitchwebostv.hls",
+  "version": "1.0.0",
+  "description": "SmartTwitchTV local HLS playlist service",
+  "main": "hls_service.js",
+  "license": "GPL-3.0-or-later"
+}

--- a/webos/service/services.json
+++ b/webos/service/services.json
@@ -1,0 +1,10 @@
+{
+  "id": "com.tbsniller.smarttwitchwebostv.hls",
+  "description": "SmartTwitchTV local HLS playlist service",
+  "services": [
+    {
+      "name": "com.tbsniller.smarttwitchwebostv.hls",
+      "description": "Fetches Twitch master playlists outside browser CORS limits"
+    }
+  ]
+}

--- a/webos/service/services.json
+++ b/webos/service/services.json
@@ -4,7 +4,15 @@
   "services": [
     {
       "name": "com.tbsniller.smarttwitchwebostv.hls",
-      "description": "Fetches Twitch master playlists outside browser CORS limits"
+      "description": "Fetches Twitch master playlists outside browser CORS limits",
+      "commands": [
+        {
+          "name": "fetchPlaylist",
+          "description": "Fetch an usher playlist and return its M3U8 body",
+          "public": true
+        }
+      ]
     }
-  ]
+  ],
+  "version": "1.0.0"
 }


### PR DESCRIPTION
Some browsers check for CORS policy which breaks our own HLS playlist proceessing. To work around this issue the playlist is fetched in a background JS service as CORS is only checked in the client browser. 